### PR TITLE
I modified the 'break' mixin, raising the breakpoint of desktop min width.

### DIFF
--- a/wp-content/themes/tableless/assets/css/_mixins.sass
+++ b/wp-content/themes/tableless/assets/css/_mixins.sass
@@ -11,5 +11,5 @@
       @content
 
   @else if $breakpoint == "desk"
-    @media (min-width: 992px)
+    @media (min-width: 1150px)
       @content


### PR DESCRIPTION
At a screen, with width between 1100px and 900px, some links in the navegation list could be over the logo. Raising the break limit, from 992px to 1150px, could solve this problem.

Error print:
![tablelesserror](https://cloud.githubusercontent.com/assets/14353550/17519631/2800ce40-5e23-11e6-957a-85c661ef90c5.png)
