### PR TITLE
Fixing post-related tb-box problem

### DIFF
--- a/wp-content/themes/tableless/assets/css/single.sass
+++ b/wp-content/themes/tableless/assets/css/single.sass
@@ -322,10 +322,16 @@
     display: flex
     flex-wrap: wrap
     padding: 0
+    @include break(mobile)
+      flex-direction: column
 
     .tb-box
-      flex: 1 0 30.2%
+      flex: 1 0 90%
       max-width: 30.2%
+
+      @include break(mobile)
+        max-width: 90%
+        margin: 20px auto
 
 .tb-divider
   &:after


### PR DESCRIPTION
Alterei a largura do container tb-box de tb-related-posts para 90% (quando for mobile), assim facilitando a leitura e visualização da thumbnail, e alterei o flex-direction da classe tb-related-group para column (quando for mobile), fazendo com que os itens dentro dela fiquem um abaixo do outro.