### PR TITLE
Bug Fix (404 page)

### DIFF
--- a/wp-content/themes/tableless/404.php
+++ b/wp-content/themes/tableless/404.php
@@ -13,7 +13,7 @@
 
 <section class="tb-latest-posts no-divider">
   
-    <div class="tb-container">
+    <div class="tb-latest-posts-list">
   
       <?php
         $latestPostsargs = array(


### PR DESCRIPTION
Reparei que na página 404 os posts estavam quebrados, como na print abaixo 

![Bug picture](http://i.imgur.com/VEu0A9p.png)

Então ajustei para a classe correta. 

Alterei de `tb-container` para `tb-latest-posts-list`.

![Bug fix picture](http://i.imgur.com/RBDqHhQ.png)
